### PR TITLE
Added ocp on gcp material

### DIFF
--- a/ocp/README.md
+++ b/ocp/README.md
@@ -1,0 +1,55 @@
+# OpenShift Compliant Financial Infrastructure Introduction
+
+OpenShift (OCP) is an open hybrid cloud enterprise Kubernetes platform that can be installed on a number of cloud providers including Amazon Web Services (AWS), Azure and Google Cloud Platform (GCP).
+
+This section provides an opinionated approach, documentation and working code to implement CFI security policies laid out in the [OpenShift Security Configuration (Service Accelerator)](ServiceApprovalAccelerator_OCP.md).
+
+
+The initial focus of the project team is to implement the Service Accelerator policies on OpenShift 4.11 running on [Google Cloud Platform](./gcp/), in the future this will be expanded to futher automation and include other cloud providers that OCP supports. 
+
+For each cloud provider documentation and working code will be provided to:
+
+1. Cloud provider setup and Cluster Installation
+2. Identity provider configuration
+3. Setup default network policies
+4. Updating the self signed certificates for the API Server and Router
+5. Implement OCP Compliance Operator
+6. Manual Remediation of CIS Controls
+
+Using the above will provide an OCP Cluster which is compliant with most CIS Policies. There are a number of CIS policies that require a user to make local decisions on how the policy would be implemented, CIS describe these as MANUAL. 
+
+We do provide examples of how some of these types of policies could implemented, for example adding an identity provider or replacing the self signed certificates.
+
+In step 6 we have provided some guidance on remediation of CIS control. 
+
+Below is a list of the CIS policies that a user will have to investigate how they should be implemented within their own organisation. 
+
+```console
+
+NAME                                                STATUS   SEVERITY
+ocp4-cis-audit-log-forwarding-enabled               FAIL     medium
+ocp4-cis-accounts-restrict-service-account-tokens   MANUAL   medium
+ocp4-cis-accounts-unique-service-account            MANUAL   medium
+ocp4-cis-api-server-oauth-https-serving-cert        MANUAL   medium
+ocp4-cis-api-server-openshift-https-serving-cert    MANUAL   medium
+ocp4-cis-general-apply-scc                          MANUAL   medium
+ocp4-cis-general-configure-imagepolicywebhook       MANUAL   medium
+ocp4-cis-general-default-namespace-use              MANUAL   medium
+ocp4-cis-general-default-seccomp-profile            MANUAL   medium
+ocp4-cis-general-namespaces-in-use                  MANUAL   medium
+ocp4-cis-rbac-limit-cluster-admin                   MANUAL   medium
+ocp4-cis-rbac-limit-secrets-access                  MANUAL   medium
+ocp4-cis-rbac-pod-creation-access                   MANUAL   medium
+ocp4-cis-rbac-wildcard-use                          MANUAL   medium
+ocp4-cis-scc-drop-container-capabilities            MANUAL   medium
+ocp4-cis-scc-limit-ipc-namespace                    MANUAL   medium
+ocp4-cis-scc-limit-net-raw-capability               MANUAL   medium
+ocp4-cis-scc-limit-network-namespace                MANUAL   medium
+ocp4-cis-scc-limit-privilege-escalation             MANUAL   medium
+ocp4-cis-scc-limit-privileged-containers            MANUAL   medium
+ocp4-cis-scc-limit-process-id-namespace             MANUAL   medium
+ocp4-cis-scc-limit-root-containers                  MANUAL   medium
+ocp4-cis-secrets-consider-external-storage          MANUAL   medium
+ocp4-cis-secrets-no-environment-variables           MANUAL   medium
+
+```

--- a/ocp/gcp/01_cluster_installation/cluster_installation.md
+++ b/ocp/gcp/01_cluster_installation/cluster_installation.md
@@ -1,0 +1,63 @@
+# OpenShift Compliant Financial Infrastructure
+
+## GCP Project setup and Cluster Installation 
+
+The OpenShift (OCP) Installer supports two installation methods, Installer Provisioned Infrastructure(IPI) and User Provisioned Infrastructure(UPI). IPI is an opinionated automated installation, this is the installation menthod that will be used. UPI gives users more flexibility to install OCP on pre-provisioned infrastructure, for example an on-premises installation where a firm's IT standards and policies prevent the use of an opinionated and automated installation. More details on OpenShift Installation can be found [here](https://docs.openshift.com/container-platform/4.12/installing/index.html).
+
+It is possile for OCP to be installed into a disconnected / air-gapped environment or be configured to have no public endpoints. To meet the current service accelerator requirements this is not required, the following instructions will implement a cluster that is internet connected and has public end-points. 
+
+The following provides an overview of the steps needed to install OCP on GCP, to meet the requirements of the service accelerator customisation needs to be made both at install time and as a day two change. To make the changes at install time we will use the [Installing a Cluster on GCP with Customisations](https://docs.openshift.com/container-platform/4.12/installing/installing_gcp/installing-gcp-customizations.html) installation method.
+
+Following are the high level steps to complete OCP installation, including the service accelerator polices to implement [FIPS cryptography](https://docs.openshift.com/container-platform/4.12/installing/installing-fips.html) and [OVNKubernetes Container Network Interface (CNI) plugin](https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#about-ovn-kubernetes). It is planned that in the future code will be added to this CFI project to automate these steps. 
+
+1. Setup the [GCP project](https://docs.openshift.com/container-platform/4.12/installing/installing_gcp/installing-gcp-account.html) ready for the OCP installation. This includes:
+    - Creating the GCP project Folder
+    - Enabling the API's that the OCP Installer requires
+    - Create a DNS public zone
+    - Increasing GCP quotas (if needed).
+    - Creating a GCP service account for the OCP Installer and give it the required permissions
+    - [download the OCP installer and service account key](https://docs.openshift.com/container-platform/4.12/installing/installing_gcp/installing-gcp-customizations.html) onto a local machine or a bastion where the installer is run and the installer state files can be stored.   
+
+2. Create the [installation configuration file](https://docs.openshift.com/container-platform/4.12/installing/installing_gcp/installing-gcp-customizations.html#installation-initializing_installing-gcp-customizations)
+
+    - Run the OCP installer to create the *install-config* file that will be used to implement install time customisations. Here is an example command: 
+
+```shell
+./openshift-install create install-config --dir=/Users/*home*/ocp_clusters/<cluster_name>
+```
+  - Edit the install-config YAML file to implement FIPS and OVNKubernetes, here is an example [config yaml](install-config.yaml) 
+  - Run the OCP installer to create the cluster. Here is an example command
+
+```shell
+./openshift-install create cluster --dir=/Users/*home*/ocp_clusters/<cluster_name> --log-level debug
+```
+
+Once the cluster installation completes, which normally takes 30-40 minutes, the installer output includes the OCP console url, kubeadmin userid and password and KUBECONFIG. 
+
+To access the cluster via a system:admin user use the following command:
+
+```shell
+export KUBECONFIG=/Users/*home*/ocp_clusters/<cluster_name>/auth/kubeconfig
+```
+
+
+FIPS compliance is managed via the OpenShift Compliance Operator, which will be discussed later. To confirm that the OVNKubernetes SDN has been implemeted log into the cluster and run the following commands.
+
+```shell
+oc describe network.config/cluster
+``` 
+
+Check the output for 'Network Type:  OVNKubernetes'
+
+```bash
+Status:
+  Cluster Network:
+    Cidr:               10.128.0.0/14
+    Host Prefix:        23
+  Cluster Network MTU:  1360
+  Network Type:         OVNKubernetes
+  Service Network:
+    172.30.0.0/16
+```
+
+The next step of the installation process is to set up an identity provider. An example using [HTPASSWD](/gcp/02_htpasswd_identity_provider/htpasswd_implementation.md) has been provided. OCP supports a number of identity providers, more detail can be found [here](https://docs.openshift.com/container-platform/4.10/authentication/understanding-identity-provider.html)

--- a/ocp/gcp/01_cluster_installation/install-config.yaml
+++ b/ocp/gcp/01_cluster_installation/install-config.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+baseDomain: ahamgcp.com
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+  name: worker
+  platform: {}
+  replicas: 3
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+metadata:
+  creationTimestamp: null
+  name: finosocp
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+  networkType: OVNKubernetes # >>>> change to OVNKubernetes <<<<
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  gcp:
+    projectID: finos-cfi
+    region: europe-west2
+publish: External
+fips: true  # >>>> add line to enable FIPS <<<<
+pullSecret: # >>>> REDACTED PULL SECRET <<<<

--- a/ocp/gcp/02_htpasswd_identity_provider/add_cluster_admin_role.sh
+++ b/ocp/gcp/02_htpasswd_identity_provider/add_cluster_admin_role.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Script to give finos-admin-users Cluster Admin privileges
+oc adm policy add-cluster-role-to-user cluster-admin finos-admin-1
+oc adm policy add-cluster-role-to-user cluster-admin finos-admin-2
+oc adm policy add-cluster-role-to-user cluster-admin finos-admin-3

--- a/ocp/gcp/02_htpasswd_identity_provider/htpasswd
+++ b/ocp/gcp/02_htpasswd_identity_provider/htpasswd
@@ -1,0 +1,6 @@
+finos-admin-1:$2y$05$l0C5fLpLm7t8ENXmn3RAoui3SeZhgdVFHuvu15cO.JQEGusPRfckG
+finos-admin-2:$2y$05$BKW8LUZXagjYdqBqkQzBvOZ6J5MlVE2mwEMLrqYbanXEydHPMwWMW
+finos-admin-3:$2y$05$i99OPG0nnZrv92Tfb3Ezbu.W.re1BSDfbp4Bn/UDmyAY.Qikgzbcu
+finos-user-1:$2y$05$XzGOhdC6k62KWWdW6QiDjuGebKDq1CdAzz598hyWAHwPuxNi/bQHq
+finos-user-2:$2y$05$R3ifWy2B5LtGuTWNlpbQ0.IPI2cqna/WctGhYE2vFRIAkLJfcs9JW
+finos-user-3:$2y$05$VijwQAVoBW93nIoh9LYBP.qO2J.PqkTF0yXO6IBrKGlOdegkbHgQK

--- a/ocp/gcp/02_htpasswd_identity_provider/htpasswd_implementation.md
+++ b/ocp/gcp/02_htpasswd_identity_provider/htpasswd_implementation.md
@@ -1,0 +1,144 @@
+# OpenShift Compliant Financial Infrastructure
+
+OCP supports a number of password providers, HTPasswd is used in this implementation of the FINOS CFI service accelerator, this should be updated where a different identity provider is being used.
+
+OCP supports these [identify providers](https://docs.openshift.com/container-platform/4.12/authentication/understanding-identity-provider.html), including LDAP, OpenID Connect, GitHub, Google and others. 
+
+So that the KubeAdmin user can be deleted we must first create additional administrator account(s) for the cluster. The following provides a working example using an [HTPasswd](https://docs.openshift.com/container-platform/4.12/authentication/identity_providers/configuring-htpasswd-identity-provider.html) provider.
+
+## Setting up HTPasswd 
+
+The following steps provide guidance on how this can be done. To follow the steps below login into the cluster that was deployed in the previous step as the KubeAdmin or system:admin user. 
+
+An example htpasswd file can be found [here](htpasswd), this file contains the following accounts:
+
+finos-admin-1, finos-admin-2, finos-admin-3 
+finos-user-1, finos-user-2, finos-user-3 
+
+All using the password *F1n0s_R3dH4t_123* If this file is to be used then start at step 3.
+
+1. Create an HTPasswd file with the first administrator or user acounts that you require
+
+```shell
+htpasswd -c -B -b </path/to/htpasswd> <user_name> <password>
+```
+
+2. Add any additional administrator or user accounts
+
+```shell
+htpasswd -c -B -b </path/to/users.htpasswd> <user_name> <password>
+```
+
+3. Create a generic secret using the htpasswd file.
+
+```shell
+oc create secret generic htpass-secret --from-file=htpasswd=htpasswd -n openshift-config
+```
+
+4. Update the OAUTH config to use the HTPasswd identity provider. 
+- First step is to get current copy of the config and save as a yaml file.
+
+```shell
+oc get oauth -o yaml -n openshift-config > oauth.yaml
+```
+
+  - Using an editor of your choice update *oauth.yaml* to define the HTPasswd provider, a sample *spec:* definition can be found [here](sample_htpasswd_provider_oauth.yaml).
+
+    Below is an example of an updated oauth.yaml
+
+```yaml
+apiVersion: v1
+items:
+- apiVersion: config.openshift.io/v1
+  kind: OAuth
+  metadata:
+    annotations:
+      include.release.openshift.io/ibm-cloud-managed: "true"
+      include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
+      release.openshift.io/create-only: "true"
+    creationTimestamp: "2022-07-12T11:55:27Z"
+    generation: 1
+    name: cluster
+    ownerReferences:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      uid: 1ca64482-ba72-4021-8ae2-cfc1140449a8
+    resourceVersion: "1684"
+    uid: b21d7582-8b97-464e-bff0-a7451cbc51de
+  spec:
+    identityProviders:
+    - name: my_htpasswd_provider
+      mappingMethod: claim
+      type: HTPasswd
+      htpasswd:
+        fileData:
+          name: htpass-secret
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+```
+
+  - Replace the existing OAUTH configuration with the updated oauth.yaml file using the follwing command
+
+```shell
+oc replace -f oauth.yaml
+```
+
+  - The oauth pods should then restart using the new configuration, you can check they are updated using the following command
+
+```shell
+oc get pods -n openshift-authentication
+```
+
+```bash
+NAME                               READY   STATUS        RESTARTS   AGE
+oauth-openshift-7495648bb6-68tmb   1/1     Terminating   0          20m
+oauth-openshift-7495648bb6-gqkb9   1/1     Running       0          22m
+oauth-openshift-7495648bb6-l74cv   1/1     Running       0          23m
+oauth-openshift-7cdbdd45ff-8xkt4   0/1     Pending       0          25s
+```
+
+
+  - The last step is to give the newly created administrator account *cluster admin* priveledges, this can be done using the following command
+
+```shell
+oc adm policy add-cluster-role-to-user cluster-admin finos-admin-1
+```
+
+A sample [script](add_cluster_admin_role.sh) is provided to automate this. The response that the user is not found can be ignored as it is due to the user having not yet logged into the cluster.  
+
+Once the above steps have been completed it should now be possible to login into the OCP cluster using the new credentials. 
+
+5. Login to the cluster as one of the newly created admin users
+
+```shell
+oc login -u finos-admin-1 -p F1n0s_R3dH4t_123
+```
+
+6. Check that the account has admin privileges: this can be done by using the following command, if the cluster nodes are not displayed the account being used does not have admin privileges so do not proceed with the next step until corrected.
+
+```shell
+oc get nodes
+```
+
+```bash
+NAME                                                 STATUS   ROLES    AGE   VERSION
+ocpfinos-gm7g2-master-0.c.finos-cfi.internal         Ready    master   44m   v1.23.3+e419edf
+ocpfinos-gm7g2-master-1.c.finos-cfi.internal         Ready    master   45m   v1.23.3+e419edf
+ocpfinos-gm7g2-master-2.c.finos-cfi.internal         Ready    master   44m   v1.23.3+e419edf
+ocpfinos-gm7g2-worker-a-mwzgg.c.finos-cfi.internal   Ready    worker   27m   v1.23.3+e419edf
+ocpfinos-gm7g2-worker-b-w4ljc.c.finos-cfi.internal   Ready    worker   27m   v1.23.3+e419edf
+ocpfinos-gm7g2-worker-c-28msg.c.finos-cfi.internal   Ready    worker   26m   v1.23.3+e419edf
+```
+
+7. Delete the KubeAdmin user 
+
+```shell
+oc delete secrets kubeadmin -n kube-system
+```
+
+
+The next [step](/gcp/03_default_network_policy/default_network_policy_implementation.md) will be to add default network policies for non control plane projects. 

--- a/ocp/gcp/02_htpasswd_identity_provider/oauth.yaml
+++ b/ocp/gcp/02_htpasswd_identity_provider/oauth.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+items:
+- apiVersion: config.openshift.io/v1
+  kind: OAuth
+  metadata:
+    annotations:
+      include.release.openshift.io/ibm-cloud-managed: "true"
+      include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
+      release.openshift.io/create-only: "true"
+    creationTimestamp: "2022-07-12T11:55:27Z"
+    generation: 1
+    name: cluster
+    ownerReferences:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      uid: 1ca64482-ba72-4021-8ae2-cfc1140449a8
+    resourceVersion: "1684"
+    uid: b21d7582-8b97-464e-bff0-a7451cbc51de
+  spec:
+    identityProviders:
+    - name: my_htpasswd_provider 
+      mappingMethod: claim 
+      type: HTPasswd
+      htpasswd:
+        fileData:
+          name: htpass-secret 
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/ocp/gcp/02_htpasswd_identity_provider/sample_htpasswd_provider_oauth.yaml
+++ b/ocp/gcp/02_htpasswd_identity_provider/sample_htpasswd_provider_oauth.yaml
@@ -1,0 +1,9 @@
+# Copy and paste following into oauth.yaml replacing existing spec: definition
+spec:
+  identityProviders:
+  - name: my_htpasswd_provider 
+    mappingMethod: claim 
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: htpass-secret 

--- a/ocp/gcp/03_default_network_policy/default_network_policy_implementation.md
+++ b/ocp/gcp/03_default_network_policy/default_network_policy_implementation.md
@@ -1,0 +1,183 @@
+# OpenShift Compliant Financial Infrastructure
+
+A CIS policy requirement is for non control plane projects/namespaces to have network policies to isolate traffic in the cluster network.
+
+OCP and the OVNKubernetes CNI support network policies. To implement network policies as a default we will use a [default project template](https://docs.openshift.com/container-platform/4.12/networking/network_policy/default-network-policy.html) to define these network policies.
+
+
+## Creating a default network policy for projects
+
+
+1. As a cluster admin user create a default project template:
+
+```bash
+oc adm create-bootstrap-project-template -o yaml > template.yaml
+```
+
+2. Create the default project template in the openshift-config namespace
+
+```bash
+oc create -f template.yaml -n openshift-config
+```
+
+3. So that this template is used we must edit the project config resiource to use template created in the last step
+
+```bash
+oc edit project.config.openshift.io/cluster
+```
+add the following:
+
+```yaml
+spec:
+  projectRequestTemplate:
+    name: project-request
+```
+see following example
+
+```yaml
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: config.openshift.io/v1
+kind: Project
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  creationTimestamp: "2022-07-12T11:55:34Z"
+  generation: 2
+  name: cluster
+  ownerReferences:
+  - apiVersion: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+    uid: 1ca64482-ba72-4021-8ae2-cfc1140449a8
+  resourceVersion: "333899"
+  uid: a33cf655-92f5-4623-aa61-06f10be2de5c
+spec:
+  projectRequestTemplate:
+    name: project-request
+```
+
+
+4. The following will setup a network policy which provides [multitenant isolation](https://docs.openshift.com/container-platform/4.12/networking/network_policy/multitenant-network-policy.html). This comprises of three network polices:
+
+    - allow-from-openshift-ingress
+    - allow-from-openshift-monitoring
+    - allow-same-namespace
+
+To add these policies to the default project template we will edit the default project config resource:
+
+```bash
+oc edit template project-request -n openshift-config
+```
+
+Copy the network policies yaml from this [sample](multi_tenant_isolation_netpol.yaml) 
+
+Sample can be seen below:
+
+```yaml
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  creationTimestamp: "2022-07-13T08:46:57Z"
+  name: project-request
+  namespace: openshift-config
+  resourceVersion: "337531"
+  uid: 975b5d14-d836-4cc8-8e72-447e005a0760
+objects:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-ingress
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            policy-group.network.openshift.io/ingress: ""
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-monitoring
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-same-namespace
+  spec:
+    ingress:
+    - from:
+      - podSelector: {}
+    podSelector: null
+- apiVersion: project.openshift.io/v1
+  kind: Project
+  metadata:
+    annotations:
+      openshift.io/description: ${PROJECT_DESCRIPTION}
+      openshift.io/display-name: ${PROJECT_DISPLAYNAME}
+      openshift.io/requester: ${PROJECT_REQUESTING_USER}
+    creationTimestamp: null
+    name: ${PROJECT_NAME}
+  spec: {}
+  status: {}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    name: admin
+    namespace: ${PROJECT_NAME}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: ${PROJECT_ADMIN_USER}
+parameters:
+- name: PROJECT_NAME
+- name: PROJECT_DISPLAYNAME
+- name: PROJECT_DESCRIPTION
+- name: PROJECT_ADMIN_USER
+- name: PROJECT_REQUESTING_USER
+```
+
+5. To test that network policies are being added to new, non control plane, projects / namespaces by default create a new project and check that the multi-tenant network polices have been created: 
+
+```bash
+oc new-project test-network-policy
+```
+
+```bash
+oc get networkpolicy
+```
+
+The following policies should be seen:
+
+```console
+NAME                              POD-SELECTOR   AGE
+allow-from-openshift-ingress      <none>         16s
+allow-from-openshift-monitoring   <none>         16s
+allow-same-namespace              <none>         16s
+```
+
+The next [step](/gcp/04_replace_api_router_certs/replace_api_router_certs.md) will replace the self signed certificates for the API Server and Router. 

--- a/ocp/gcp/03_default_network_policy/multi_tenant_isolation_netpol.yaml
+++ b/ocp/gcp/03_default_network_policy/multi_tenant_isolation_netpol.yaml
@@ -1,0 +1,35 @@
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-ingress
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            policy-group.network.openshift.io/ingress: ""
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-monitoring
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-same-namespace
+  spec:
+    podSelector:
+    ingress:
+    - from:
+      - podSelector: {}

--- a/ocp/gcp/04_replace_api_router_certs/replace_api_router_certs.md
+++ b/ocp/gcp/04_replace_api_router_certs/replace_api_router_certs.md
@@ -1,0 +1,126 @@
+# OpenShift Compliant Financial Infrastructure
+
+OpenShift uses certificates to encrypt the communication with the Web Console as well as applications exposed as Routes. Without any further customisation the install process will create self-signed certificates. While these work they usually trigger security warnings about unknown certificates in Web Browsers and should be replaced with approved certificates for both the API and router endpoints. 
+
+The following steps uses [acme.sh](https://github.com/acmesh-official/acme.sh) and [Let's Encrypt](https://letsencrypt.org/) this example is for PoC purposes and a firms approved certificates should be used for ots OCP deployments. 
+
+## Day 2 Replace API and Router Certificates
+
+1. Install [acme.sh](https://github.com/acmesh-official/acme.sh) a number of installation options are provided in [here](https://github.com/acmesh-official/acme.sh#1-how-to-install)
+
+2. By default acme.sh uses [ZeroSSL.com](https://github.com/acmesh-official/acme.sh/wiki/ZeroSSL.com-CA) we will use [Let's Encrypt](https://letsencrypt.org/), to set that as the default use the following command
+
+```shell
+acme.sh  --set-default-ca  --server letsencrypt
+```
+
+3. Identify the FQDN for both the API and Router endpoints (you need to be logged onto OCP) and assign them as variables
+
+API endpoint:
+
+```shell
+oc whoami --show-server | cut -f 2 -d ':' | cut -f 3 -d '/' | sed 's/-api././'
+```
+*api.<clustername>.><domainname>.com*
+
+Router endpoint:
+
+```shell
+oc get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.domain}'
+```
+
+*apps.<clustername>.><domainname>.com*
+
+
+4. acme.sh support a large number of DNS providers including Google Cloud DNS, this [link](https://github.com/acmesh-official/acme.sh/wiki/dnsapi#49-use-google-cloud-dns-api-to-automatically-issue-cert) provides more information. To issue a certificate use the following steps:
+
+    - authenticate with GCP using 'gcloud init' go through the dialog to initiase the connection 
+    - in the .acme.sh use following command to issue the certificates
+      
+      ```bash
+      acme.sh --issue -d api.<cluster____name>.><domain_name>.com --dns dns_gcloud
+      acme.sh --issue -d *.apps.<cluster_name>.><domain_name>.com --dns dns_gcloud
+      ```
+
+    - move the certificates from the acme.sh path to a known working directory, for this example we are using *home*/certificates/api and *home*/certificates/router
+
+      ```bash
+      acme.sh --install-cert -d api.<cluster_name>.><domain_name>.com --cert-file /Users/*home*/certificates/api/cert.pem --key-file /Users/*home*/certificates/api/key.pem --fullchain-file /Users/*home*/certificates/api/fullchain.pem --ca-file /Users/*home*/certificates/api/ca.cer
+
+      acme.sh --install-cert -d *.apps.<cluster_name>.><domain_name>.com --cert-file /Users/*home*/certificates/router/cert.pem --key-file /Users/*home*/certificates/router/key.pem --fullchain-file /Users/*home*/certificates/router/fullchain.pem --ca-file /Users/*home*/certificates/router/ca.cer
+      ```
+
+      check that the certificates exist in the target directories.
+
+5. To replace the API endpoint certificate use following command, more details can be found in the [OCP documentation](https://docs.openshift.com/container-platform/4.12/security/certificates/api-server.html). Before running the command below CD into the directory with the API certificates, e.g. /Users/*home*/certificates/api/ 
+
+      - Create a secret using the API endpoint certifcate chain and private key created in the previous step
+
+    ```shell
+    oc create secret tls api-certs --cert=fullchain.pem --key=key.pem -n openshift-config
+    ```
+
+      - Patch the apiserver to use the new certificate
+    
+    ```shell
+    oc patch apiserver cluster --type=merge -p '{"spec":{"servingCerts": {"namedCertificates": [{"names": ["api.finos1.ahamgcp.com"], "servingCertificate": {"name": "api-certs"}}]}}}'
+    ```
+
+      - To check the update has been made to the apiserver review the servingCerts using the following command
+
+    ```shell
+    oc get apiserver cluster -o yaml
+    ```
+    
+    *servingCerts:*
+    ```yaml
+    namedCertificates:
+    - names:
+      - api.<clustername>.<domainname>.com
+      servingCertificate:
+        name: api-certs
+     ```
+
+      - The changes will be rolled out which will take a few minutes to check progress use the following command
+
+      ```shell
+      oc get clusteroperators kube-apiserver
+      ```
+
+      The following output shows that the change has been made, do not proceed until progressing is false
+
+
+```console
+NAME              VERSION    AVAILABLE    PROGRESSING   DEGRADED   SINCE    MESSAGE 
+kube-apiserver    4.10.3     True         True          False      98m     NodeInstallerProgressing: 3 nodes are at revision 9; 0 nodes have achieved new revision 10 
+kube-apiserver    4.10.3     True         True          False      98m     NodeInstallerProgressing: 3 nodes are at revision 9; 0 nodes have achieved new revision 10 
+kube-apiserver    4.10.3     True         True          False      98m     NodeInstallerProgressing: 3 nodes are at revision 9; 0 nodes have achieved new revision 10 
+kube-apiserver    4.10.3     True         True          False      98m     NodeInstallerProgressing: 3 nodes are at revision 9; 0 nodes have achieved new revision 11 
+kube-apiserver    4.10.3     True         True          False      102m    NodeInstallerProgressing: 2 nodes are at revision 9; 1 nodes are at revision 11 
+kube-apiserver    4.10.3     True         False         False      122m 
+```
+
+
+Once completed you will need to log back into the API server. To confirm that the new certificate is being used the following curl command can be used:
+
+```shell
+curl -v https://api.<clustername>.<domainname>.com:6443
+```
+
+6. To replace the default Router endpoint certificate use following command, more details can be found in the [OCP documentation](https://docs.openshift.com/container-platform/4.12/security/certificates/replacing-default-ingress-certificate.html). Before running the command below CD into the directory with the API certificates, e.g. /Users/*home*/certificates/router/ 
+
+ - Create a secret using the Router endpoint certifcate chain and private key created in the previous step
+
+    ```shell
+    oc create secret tls router-certs --cert=fullchain.pem --key=key.pem -n openshift-ingress
+    ```
+
+  - Patch the apiserver to use the new certificate
+    
+    ```shell
+    oc patch ingresscontroller.operator default --type=merge -p '{"spec":{"defaultCertificate": {"name": "router-certs"}}}' -n openshift-ingress-operator
+    ```
+
+It will take a few minutes for the update to replicate, to check login to the OCP Console and check that the connection is secure and using the new certificate. 
+
+The next step is to complete the [day 2 customisation](/gcp/05_implement_ocp_compliance_operator/implement_ocp_compliance_operator.md).

--- a/ocp/gcp/05_implement_ocp_compliance_operator/00-namespace-object.yaml
+++ b/ocp/gcp/05_implement_ocp_compliance_operator/00-namespace-object.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-compliance

--- a/ocp/gcp/05_implement_ocp_compliance_operator/01-operator-group-object.yaml
+++ b/ocp/gcp/05_implement_ocp_compliance_operator/01-operator-group-object.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: compliance-operator
+  namespace: openshift-compliance
+spec:
+  targetNamespaces:
+  - openshift-compliance

--- a/ocp/gcp/05_implement_ocp_compliance_operator/02-subscription-object.yaml
+++ b/ocp/gcp/05_implement_ocp_compliance_operator/02-subscription-object.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: "release-0.1"
+  installPlanApproval: Automatic
+  name: compliance-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ocp/gcp/05_implement_ocp_compliance_operator/03-scansetting-cis-ocp4-default.yaml
+++ b/ocp/gcp/05_implement_ocp_compliance_operator/03-scansetting-cis-ocp4-default.yaml
@@ -1,0 +1,15 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: cis-compliance-ocp4
+profiles:
+  - name: ocp4-cis
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+  - name: ocp4-cis-node
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: default-auto-apply
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1

--- a/ocp/gcp/05_implement_ocp_compliance_operator/implement_ocp_compliance_operator.md
+++ b/ocp/gcp/05_implement_ocp_compliance_operator/implement_ocp_compliance_operator.md
@@ -1,0 +1,236 @@
+# OpenShift Compliant Financial Infrastructure
+
+To complete the setup of the cluster to meet the policy requirements laid out in the [OpenShift Security Configuration (Service Accelerator)](/accelerators/kubernetes/ocp/ServiceApprovalAccelerator_OCP.md) we will use the [OpenShift Compliance Operator](https://docs.openshift.com/container-platform/4.12/security/compliance_operator/compliance-operator-release-notes.html). The Compliance Operator lets OpenShift Container Platform administrators describe the required compliance state of a cluster and it provides them with an overview of gaps and ways to remediate them. The compliance operator supports a number of [compliance standards](https://docs.openshift.com/container-platform/4.12/security/compliance_operator/compliance-operator-supported-profiles.html) for example NIST and CIS. 
+
+To meet the policies as laid out in the service accelerator the OpenShift CIS Benchmark profile will be used.
+
+The compliance operator is a Custom Resource Definition (CRD) and includes a number of kubernetes objects, more details on these object can be found in [here](https://github.com/openshift/compliance-operator/blob/master/doc/crds.md). 
+
+The Compliance Operator, or any other operator, can be installed on OCP using the Administrator UI or the CLI. Instructions on both methods can be found [here](https://docs.openshift.com/container-platform/4.12/security/compliance_operator/compliance-operator-installation.html). 
+
+Below we will decribe both the installation and configuration of the CIS profile using the command line. 
+
+## Day 2 Customisation 
+
+### Compliance Operator Installation and verification
+
+1. Create the compliance operator namespace
+
+```shell
+oc create -f 00-namespace-object.yaml
+```
+
+2. Go into the openshift-compliance project
+
+```shell
+oc project openshift-compliance
+```
+
+3. Create the compliance operator OperatorGroup object
+
+```shell
+oc create -f 01-operator-group-object.yaml
+```
+
+4. Create the compliance operator subscription object, this will initiate the operator installation 
+
+```shell
+oc create -f 02-subscription-object.yaml
+```
+
+5. Verify that the installation was sucessful and that the operator is running and look at the compliance operator deployment. 
+
+```shell
+oc get csv -n openshift-compliance -w
+```
+
+```console
+NAME                          DISPLAY               VERSION   REPLACES   PHASE
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Pending
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Pending
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               InstallReady
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               InstallReady
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Installing
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Installing
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Succeeded
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Failed
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Pending
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               InstallReady
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Installing
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Installing
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Installing
+compliance-operator.v0.1.52   Compliance Operator   0.1.52               Succeeded
+```
+
+```shell
+oc get deploy -n openshift-compliance
+```
+
+```console
+NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
+compliance-operator              1/1     1            1           2m12s
+ocp4-openshift-compliance-pp     0/1     1            0           45s
+rhcos4-openshift-compliance-pp   0/1     1            0           45s
+```
+
+6. The compliance operator ships with a number of complaince profiles, these can be seen using the following command
+
+```shell
+oc get profiles.compliance
+```
+
+```console
+NAME                 AGE
+ocp4-cis             63s
+ocp4-cis-node        63s
+ocp4-e8              63s
+ocp4-high            63s
+ocp4-high-node       63s
+ocp4-moderate        63s
+ocp4-moderate-node   63s
+ocp4-nerc-cip        62s
+ocp4-nerc-cip-node   62s
+ocp4-pci-dss         62s
+ocp4-pci-dss-node    62s
+rhcos4-e8            58s
+rhcos4-high          57s
+rhcos4-moderate      57s
+rhcos4-nerc-cip      57s
+```
+
+7. The next step is to set up the compliance scanning using the CIS profile, the default profiles that is being used will run scans on a daily base and, where possible. auto-remiate any complaince issues.
+
+```shell
+oc create -f 03-scansetting-cis-ocp4-default.yaml
+```
+
+8. The creation of the scan object will trigger the initial compliance scan to take please against the CIS compliance profile, to check that the compliance scan is running use the following command: 
+
+```shell
+oc get compliancesuite -w
+```
+
+```console
+NAME                  PHASE       RESULT
+cis-compliance-ocp4   LAUNCHING   NOT-AVAILABLE
+cis-compliance-ocp4   LAUNCHING   NOT-AVAILABLE
+cis-compliance-ocp4   LAUNCHING   NOT-AVAILABLE
+cis-compliance-ocp4   RUNNING     NOT-AVAILABLE
+cis-compliance-ocp4   RUNNING     NOT-AVAILABLE
+cis-compliance-ocp4   RUNNING     NOT-AVAILABLE
+cis-compliance-ocp4   AGGREGATING   NOT-AVAILABLE
+cis-compliance-ocp4   AGGREGATING   NOT-AVAILABLE
+cis-compliance-ocp4   AGGREGATING   NOT-AVAILABLE
+cis-compliance-ocp4   DONE          NON-COMPLIANT
+cis-compliance-ocp4   DONE          NON-COMPLIANT
+```
+
+9. Once the scan is complete the following command can be used to check the complaince scan results, when setting up the compliance scan object (step 7), we set the complaince operator to automatical remidate compliance failures. 
+
+```shell
+oc get ccr
+```
+
+An extract of the oc get ccr command can be seen below.
+
+
+```console
+NAME                                                                           STATUS   SEVERITY
+ocp4-cis-accounts-restrict-service-account-tokens                              MANUAL   medium
+ocp4-cis-accounts-unique-service-account                                       MANUAL   medium
+ocp4-cis-api-server-admission-control-plugin-alwaysadmit                       PASS     medium
+ocp4-cis-api-server-admission-control-plugin-alwayspullimages                  PASS     high
+ocp4-cis-api-server-admission-control-plugin-namespacelifecycle                PASS     medium
+ocp4-cis-api-server-admission-control-plugin-noderestriction                   PASS     medium
+ocp4-cis-api-server-admission-control-plugin-scc                               PASS     medium
+ocp4-cis-api-server-admission-control-plugin-securitycontextdeny               PASS     medium
+ocp4-cis-api-server-admission-control-plugin-serviceaccount                    PASS     medium
+ocp4-cis-api-server-anonymous-auth                                             PASS     medium
+ocp4-cis-api-server-api-priority-gate-enabled                                  PASS     medium
+ocp4-cis-api-server-audit-log-maxbackup                                        PASS     low
+ocp4-cis-api-server-audit-log-maxsize                                          PASS     medium
+ocp4-cis-api-server-audit-log-path                                             PASS     high
+ocp4-cis-api-server-auth-mode-no-aa                                            PASS     medium
+ocp4-cis-api-server-auth-mode-node                                             PASS     medium
+ocp4-cis-api-server-auth-mode-rbac                                             PASS     medium
+ocp4-cis-api-server-basic-auth                                                 PASS     medium
+ocp4-cis-api-server-bind-address                                               PASS     low
+ocp4-cis-api-server-client-ca                                                  PASS     medium
+ocp4-cis-api-server-encryption-provider-cipher                                 FAIL     medium
+ocp4-cis-api-server-encryption-provider-config                                 FAIL     medium
+```
+
+Initially a number of the compliance checks will FAIL, many of them will be remediated automatically by the compliance operator. This remediation process can take sometime (hours). These remediation a actioned by the OCP cluster operators, using the following command the progress of these cluster operators can be seen.
+
+'''shell
+oc get co
+```
+Below is an example of the output of this command.
+
+```console
+NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+authentication                             4.10.3    True        True          False      76m     APIServerDeploymentProgressing: deployment/apiserver.openshift-oauth-apiserver: 1/3 pods have been updated to the latest generation
+baremetal                                  4.10.3    True        False         False      3h51m   
+cloud-controller-manager                   4.10.3    True        False         False      3h56m   
+cloud-credential                           4.10.3    True        False         False      3h57m   
+cluster-autoscaler                         4.10.3    True        False         False      3h51m   
+config-operator                            4.10.3    True        False         False      3h53m   
+console                                    4.10.3    True        False         False      76m     
+csi-snapshot-controller                    4.10.3    True        False         False      3h52m   
+dns                                        4.10.3    True        False         False      3h51m   
+etcd                                       4.10.3    True        False         False      3h50m   
+image-registry                             4.10.3    True        False         False      3h43m   
+ingress                                    4.10.3    True        False         False      3h42m   
+insights                                   4.10.3    True        False         False      3h33m   
+kube-apiserver                             4.10.3    True        True          False      3h38m   NodeInstallerProgressing: 2 nodes are at revision 9; 1 nodes are at revision 10
+kube-controller-manager                    4.10.3    True        False         False      3h49m   
+kube-scheduler                             4.10.3    True        False         False      3h49m   
+kube-storage-version-migrator              4.10.3    True        False         False      56s     
+machine-api                                4.10.3    True        False         False      3h48m   
+machine-approver                           4.10.3    True        False         False      3h51m   
+machine-config                             4.10.3    True        False         False      3h51m   
+marketplace                                4.10.3    True        False         False      3h51m   
+monitoring                                 4.10.3    True        False         False      3h31m   
+network                                    4.10.3    True        False         False      3h53m   
+node-tuning                                4.10.3    True        False         False      3h51m   
+openshift-apiserver                        4.10.3    True        True          False      3h38m   APIServerDeploymentProgressing: deployment/apiserver.openshift-apiserver: 1/3 pods have been updated to the latest generation
+openshift-controller-manager               4.10.3    True        False         False      3h51m   
+openshift-samples                          4.10.3    True        False         False      3h49m   
+operator-lifecycle-manager                 4.10.3    True        False         False      3h52m   
+operator-lifecycle-manager-catalog         4.10.3    True        False         False      3h52m   
+operator-lifecycle-manager-packageserver   4.10.3    True        False         False      29s     
+service-ca                                 4.10.3    True        False         False      3h53m   
+storage                                    4.10.3    True        True          False      3h52m   GCPPDCSIDriverOperatorCRProgressing: GCPPDDriverControllerServiceControllerProgressing: Waiting for Deployment to deploy pods
+```
+
+### The OCP CIS Benchmark
+
+The OCP CIS Benchmark consists of three sets of policies:
+
+- *ocp-cis* for Cluster polies
+- *ocp-node-master* for control node policies
+- *ocp-node-worker* for compute node policies
+
+The following commmands can be used to do compliance checks for each of the above policies. The examples below look for compliance checks that have *FAILED*, to check for policies that have passed use *PASS* or policies that require manual evaluation use *MANUAL*.
+
+```bash
+oc get compliancecheckresults -l compliance.openshift.io/scan-name=ocp4-cis,compliance.openshift.io/check-status=FAIL
+
+oc get compliancecheckresults -l compliance.openshift.io/scan-name=ocp4-cis-node-master,compliance.openshift.io/check-status=FAIL
+
+oc get compliancecheckresults -l compliance.openshift.io/scan-name=ocp4-cis-node-worker,compliance.openshift.io/check-status=FAIL
+```
+
+Once any remediation have be made the following commands can be used to trigger a compliance rescan. A [script](rescan.sh) to trigger a rescan of all scans has been provided. 
+
+```bash
+oc annotate compliancescans/ocp4-cis compliance.openshift.io/rescan=
+
+oc annotate compliancescans/ocp4-cis-node-master compliance.openshift.io/rescan=
+
+oc annotate compliancescans/ocp4-cis-node-worker compliance.openshift.io/rescan=
+```
+
+The compliance operator will auto-remediate all CIS policies with the exception of those policies that the CIS define as requiring manual rediation. In the next section we will address these [manual remediations](/gcp/06_remediation_of_manual_CIS_controls/Remediation_of_manual_CIS_controls.md).

--- a/ocp/gcp/05_implement_ocp_compliance_operator/rescan.sh
+++ b/ocp/gcp/05_implement_ocp_compliance_operator/rescan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Script to trigger rescan
+oc annotate compliancescans/ocp4-cis compliance.openshift.io/rescan=
+oc annotate compliancescans/ocp4-cis-node-master compliance.openshift.io/rescan=
+oc annotate compliancescans/ocp4-cis-node-worker compliance.openshift.io/rescan=

--- a/ocp/gcp/06_remediation_of_manual_CIS_controls/Remediation_of_manual_CIS_controls.md
+++ b/ocp/gcp/06_remediation_of_manual_CIS_controls/Remediation_of_manual_CIS_controls.md
@@ -1,0 +1,126 @@
+# OpenShift Compliant Financial Infrastructure
+
+## In this section we will remediate the CIS Manual policies.
+
+In the previous section we implemented the OCP Compliance Operator and
+the CIS Benchmark for the OCP cluster, control and compute nodes. The
+Compliance Operator was able to auto-remediate all failing policies and
+at this point we should only have policies that require manual intervention.
+
+There are two kinds of checks that require a manual intervention:
+ - checks that would result in a FAIL, but do not have a corresponding `ComplianceRemediation`
+   object. These are rules that require setting up something that the operator can't know
+   beforehand. An example is setting up cluster forwarding
+ - checks that would result in a MANUAL result. These need to be evaluated
+   on a case-by-case basis.
+
+Let's first illustrate how can we get more information on the checks and the rules
+that those check cover.
+
+### Getting more information about compliance rules
+
+In general, it is often useful to get more information about a particular check
+or a rule - why does the check exist, why could it fail etc.
+
+After applying all the remediations, the following command:
+```shell
+oc get compliancecheckresults -l compliance.openshift.io/scan-name=ocp4-cis,compliance.openshift.io/check-status=FAIL
+```
+
+Should return one rule that are still failing:
+```shell
+NAME                                                      STATUS   SEVERITY
+ocp4-cis-audit-log-forwarding-enabled            FAIL     medium
+```
+
+Note that if you started from a default installation, there would have been
+more failing checks, e.g. one that tests that kubeadmin had been removed, that an IDP is configured or network policies have been set, but by following this guide those had been remediated already.
+
+Let's illustrate that on the first check that enables log forwarding.
+We'll examine the check first:
+
+```shell
+oc describe ccr ocp4-cis-audit-log-forwarding-enabled
+```
+
+Several attributes are useful in the describe output:
+ - instructions: This is a shell command you can run to evaluate the rule manually
+ - description: Why is the rule included, or why is the check important
+ - annotations.compliance.openshift.io/rule: Which rule.compliance object does this check represent
+
+Let's find more information from the rule object:
+
+```shell
+oc get rules | grep audit-log-forwarding-enabled
+```
+```bash
+ocp4-audit-log-forwarding-enabled                                                            117m
+```
+To get more detail on this rule use the following command:
+
+```shell
+oc describe rules ocp4-audit-log-forwarding-enabled
+```
+
+The `rule` object contains some of the same data as the `ComplianceCheckResult`
+object, but its description also contains more information, including links
+to OpenShift documentation that tells us how to enable cluster log forwarding
+which would satisfy the rule. By following the documentation, we can install
+the `ClusterLoggingOperator`, create an instance of `ClusterLogging` and an
+instance of `ClusterLogForwarder`, which would satisfy the check.
+
+### Addressing the MANUAL rules
+
+Each compliance check also has a number of MANUAL rules. These are rules that
+the operator can't check automatically for one reason or another, most often
+because it lacks the knowledge that pertains to the particular environment and
+would allow to evaluate the result. List the manual checks with:
+
+```shell
+oc get compliancecheckresults -l compliance.openshift.io/scan-name=ocp4-cis,compliance.openshift.io/check-status=MANUAL
+```
+
+Let's pick one check at random:
+```shell
+$ oc describe ccr ocp4-cis-scc-limit-privileged-containers
+```
+
+The instructions attribute of the check contains:
+```console
+Inspect each SCC returned from running the following command:
+$ oc get scc
+Review each SCC for those that have allowPrivilegedContainer set to true.
+Next, examine the outputs of the following commands:
+$ oc describe roles --all-namespaces
+$ oc describe clusterroles
+For any role/clusterrole that reference the
+securitycontextconstraints resource with the resourceNames
+of the SCCs that have allowPrivilegedContainer, examine the associated
+rolebindings to account for the users that are bound to the role. Review the
+account to determine if allowPrivilegedContainer is truly required.
+```
+
+As you can see, this is an operational control where the organization decided
+which roles or clusterRole objects are allowed to use a privileged SCC.
+This check must therefore be addressed manually or using a third-party policy
+engine such as OPA that would limit what roles or clusterRoles can bind to
+these privileged SCCs.
+
+To filter our manual checks that have been addressed in one way or another, we
+can use a `tailoredProfile`, disabling rules that were checked already:
+```yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: TailoredProfile
+metadata:
+  name: cis-filter-checked-manual-rules
+spec:
+  extends: ocp4-cis
+  title: OCP4 CIS with fewer manual rules
+  description: This tailored profile disables manual rules that we have addressed
+  disableRules:
+    - name: ocp4-scc-limit-privileged-containers
+      rationale: We have OPA rules that prevent new clusterRoles or roles from binding to this SCC
+```
+
+For more information on `TailoredProfile` resources, please refer to the
+[compliance operator documentation](https://docs.openshift.com/container-platform/4.12/security/compliance_operator/compliance-operator-tailor.html)

--- a/ocp/gcp/README.md
+++ b/ocp/gcp/README.md
@@ -1,0 +1,14 @@
+# OpenShift Compliant Financial Infrastructure - Google Cloud Platform
+
+This folder provides documentation and working code to install and customise OpenShift(OCP) on Google Cloud Platform(GCP) to meet the policies set out in the [Red Hat OpenShift Compliant Financial Infrastructure Service Accelerator document](/accelerators/kubernetes/ocp/ServiceApprovalAccelerator_OCP.md). 
+
+There are six steps to complete cluster installation and customisation:
+
+1. [Cloud provider setup and Cluster Installation](/gcp/01_cluster_installation/cluster_installation.md)
+2. [Identity provider configuration](/gcp/02_htpasswd_identity_provider/htpasswd_implementation.md)
+3. [Setup default network policies](/gcp/03_default_network_policy/default_network_policy_implementation.md)
+4. [Updating the self signed certificates for the API Server and Router](/gcp/04_replace_api_router_certs/replace_api_router_certs.md)
+5. [Implement OCP Compliance Operator](/gcp/05_implement_ocp_compliance_operator/implement_ocp_compliance_operator.md)
+6. [Manual Remediation of CIS Controls](/gcp/06_remediation_of_manual_CIS_controls/Remediation_of_manual_CIS_controls.md)
+
+


### PR DESCRIPTION
Copied materials from original cfi repo for ocp on gcp to ansible-cfi-ocp. This is an update to ocp 4.12. This is related to issues #6 and #4.